### PR TITLE
override unhelpful eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,9 +18,11 @@
     ],
     "extends": "airbnb",
     "rules": {
-        "indent": ["warn", 4],
+        "indent": ["warn", 4, {"SwitchCase": 1}],
+        "function-paren-newline": "off",
         "react/jsx-indent": ["warn", 4],
         "react/jsx-filename-extension": ["warn", {"extensions": [".js", ".jsx"]}],
+        "react/jsx-curly-brace-presence": "off",
         "import/no-extraneous-dependencies": "off",
         "import/extensions": ["warn",
             "never",


### PR DESCRIPTION
proper switch case indent 
ignore 'extraneous' jsx curly braces (because I like to write `classNames={'myClass'}`)
allow newlines in function parens